### PR TITLE
Filter qi bash scripts in /qi directory

### DIFF
--- a/lib/script-ops.sh
+++ b/lib/script-ops.sh
@@ -55,27 +55,32 @@ discover_scripts() {
         
         log "DEBUG" "Scanning repository: $repo_name"
         
-        # Find all .bash files in the repository
-        while IFS= read -r -d '' script_path; do
-            # Get relative path from repository root
-            local rel_path="${script_path#$repo_dir/}"
-            
-            # Extract script name (without .bash extension)
-            local script_name
-            script_name="$(basename "$rel_path" .bash)"
-            
-            # Skip if script name is empty or invalid
-            if [[ -z "$script_name" || "$script_name" == "." ]]; then
-                continue
-            fi
-            
-            # Add to index: script_name|repo_name|relative_path|full_path
-            echo "$script_name|$repo_name|$rel_path|$script_path" >> "$temp_index"
-            ((total_scripts++))
-            
-            log "DEBUG" "Found script: $script_name in $repo_name ($rel_path)"
-            
-        done < <(find "$repo_dir" -name "*.bash" -type f -print0 2>/dev/null)
+        # Find all .bash files in the repository, but only in /qi directory from root
+        local qi_dir="$repo_dir/qi"
+        if [[ -d "$qi_dir" ]]; then
+            while IFS= read -r -d '' script_path; do
+                # Get relative path from repository root
+                local rel_path="${script_path#$repo_dir/}"
+                
+                # Extract script name (without .bash extension)
+                local script_name
+                script_name="$(basename "$rel_path" .bash)"
+                
+                # Skip if script name is empty or invalid
+                if [[ -z "$script_name" || "$script_name" == "." ]]; then
+                    continue
+                fi
+                
+                # Add to index: script_name|repo_name|relative_path|full_path
+                echo "$script_name|$repo_name|$rel_path|$script_path" >> "$temp_index"
+                ((total_scripts++))
+                
+                log "DEBUG" "Found script: $script_name in $repo_name ($rel_path)"
+                
+            done < <(find "$qi_dir" -name "*.bash" -type f -print0 2>/dev/null)
+        else
+            log "DEBUG" "No /qi directory found in repository: $repo_name"
+        fi
     done
     
     # Sort index by script name for easier lookup

--- a/qi
+++ b/qi
@@ -320,11 +320,16 @@ cmd_add() {
         
         # Show available scripts (if any)
         local script_count
-        script_count=$(find "$(get_repo_dir "$repo_name")" -name "*.bash" -type f 2>/dev/null | wc -l)
-        if [[ $script_count -gt 0 ]]; then
-            log "INFO" "Found $script_count bash script(s) in repository"
+        local qi_dir="$(get_repo_dir "$repo_name")/qi"
+        if [[ -d "$qi_dir" ]]; then
+            script_count=$(find "$qi_dir" -name "*.bash" -type f 2>/dev/null | wc -l)
+            if [[ $script_count -gt 0 ]]; then
+                log "INFO" "Found $script_count bash script(s) in repository /qi directory"
+            else
+                log "INFO" "No bash scripts found in repository /qi directory"
+            fi
         else
-            log "INFO" "No bash scripts found in repository"
+            log "INFO" "No /qi directory found in repository (no scripts will be available)"
         fi
     else
         log "ERROR" "Failed to add repository: $url"

--- a/test.sh
+++ b/test.sh
@@ -146,8 +146,9 @@ test_script_functionality() {
     # Add repository with scripts
     "$QI_SCRIPT" add https://github.com/octocat/Hello-World.git test-scripts >/dev/null 2>&1
     
-    # Create test script
-    local test_script_dir="$TEST_CACHE_DIR/test-scripts"
+    # Create test script in qi directory
+    local test_script_dir="$TEST_CACHE_DIR/test-scripts/qi"
+    mkdir -p "$test_script_dir"
     cat > "$test_script_dir/test.bash" << 'EOF'
 #!/bin/bash
 echo "Test script executed successfully"


### PR DESCRIPTION
Restrict qi's script discovery to only `.bash` files within a `/qi` directory to improve script organization and isolation.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b208fac-aaf2-482d-8fa7-d2758fa5a163">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1b208fac-aaf2-482d-8fa7-d2758fa5a163">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

