### PR TITLE
Remove Ubuntu 20 integration tests

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -17,7 +17,7 @@ The qi project now includes a comprehensive set of GitHub Actions workflows to e
 - Comprehensive test suite execution
 - Coverage report generation
 - Integration testing with real repositories
-- OS compatibility testing (Ubuntu 20.04, 22.04, latest)
+- OS compatibility testing (Ubuntu 22.04, latest)
 - Security checks and documentation validation
 
 **Jobs**:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-latest]
+        os: [ubuntu-22.04, ubuntu-latest]
         
     steps:
     - name: Checkout code

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-latest]
+        os: [ubuntu-22.04, ubuntu-latest]
         install-method: [curl, wget, manual]
         user-type: [root, sudo]
             


### PR DESCRIPTION
Remove Ubuntu 20.04 integration tests to reduce CI/CD execution time and maintenance overhead.

---
<a href="https://cursor.com/background-agent?bcId=bc-306af6f8-fae7-45e7-b617-a698d47b5796">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-306af6f8-fae7-45e7-b617-a698d47b5796">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

