### PR TITLE
Fix shellcheck errors in shell scripts

### DIFF
--- a/tests/test_cache.sh
+++ b/tests/test_cache.sh
@@ -24,11 +24,14 @@ if [[ ! -d "$LIB_DIR" ]]; then
 fi
 
 # Source required libraries
-# shellcheck source=../lib/utils.sh
+# shellcheck source=lib/utils.sh
+# shellcheck disable=SC1091
 . "$LIB_DIR/utils.sh"
-# shellcheck source=../lib/config.sh
+# shellcheck source=lib/config.sh
+# shellcheck disable=SC1091
 . "$LIB_DIR/config.sh"
-# shellcheck source=../lib/cache.sh
+# shellcheck source=lib/cache.sh
+# shellcheck disable=SC1091
 . "$LIB_DIR/cache.sh"
 
 # Test fixtures and setup
@@ -349,5 +352,6 @@ test_get_cache_stats() {
 }
 
 # Load and run shunit2
-# shellcheck source=../shunit2
+# shellcheck source=shunit2
+# shellcheck disable=SC1091
 . "$PROJECT_ROOT/shunit2"

--- a/tests/test_config.sh
+++ b/tests/test_config.sh
@@ -24,9 +24,11 @@ if [[ ! -d "$LIB_DIR" ]]; then
 fi
 
 # Source required libraries
-# shellcheck source=../lib/utils.sh
+# shellcheck source=lib/utils.sh
+# shellcheck disable=SC1091
 . "$LIB_DIR/utils.sh"
-# shellcheck source=../lib/config.sh
+# shellcheck source=lib/config.sh
+# shellcheck disable=SC1091
 . "$LIB_DIR/config.sh"
 
 # Test fixtures and setup
@@ -254,5 +256,6 @@ test_init_config() {
 }
 
 # Load and run shunit2
-# shellcheck source=../shunit2
+# shellcheck source=shunit2
+# shellcheck disable=SC1091
 . "$PROJECT_ROOT/shunit2"

--- a/tests/test_git_ops.sh
+++ b/tests/test_git_ops.sh
@@ -24,13 +24,17 @@ if [[ ! -d "$LIB_DIR" ]]; then
 fi
 
 # Source required libraries
-# shellcheck source=../lib/utils.sh
+# shellcheck source=lib/utils.sh
+# shellcheck disable=SC1091
 . "$LIB_DIR/utils.sh"
-# shellcheck source=../lib/config.sh
+# shellcheck source=lib/config.sh
+# shellcheck disable=SC1091
 . "$LIB_DIR/config.sh"
-# shellcheck source=../lib/cache.sh
+# shellcheck source=lib/cache.sh
+# shellcheck disable=SC1091
 . "$LIB_DIR/cache.sh"
-# shellcheck source=../lib/git-ops.sh
+# shellcheck source=lib/git-ops.sh
+# shellcheck disable=SC1091
 . "$LIB_DIR/git-ops.sh"
 
 # Test fixtures and setup
@@ -421,5 +425,6 @@ test_clone_repository_dry_run() {
 }
 
 # Load and run shunit2
-# shellcheck source=../shunit2
+# shellcheck source=shunit2
+# shellcheck disable=SC1091
 . "$PROJECT_ROOT/shunit2"

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -315,5 +315,6 @@ test_install_script_logging() {
 }
 
 # Load and run shunit2
-# shellcheck source=../shunit2
+# shellcheck source=shunit2
+# shellcheck disable=SC1091
 . "$PROJECT_ROOT/shunit2"

--- a/tests/test_integration.sh
+++ b/tests/test_integration.sh
@@ -263,5 +263,6 @@ test_qi_cleanup_on_error() {
 }
 
 # Load and run shunit2
-# shellcheck source=../shunit2
+# shellcheck source=shunit2
+# shellcheck disable=SC1091
 . "$PROJECT_ROOT/shunit2"

--- a/tests/test_script_ops.sh
+++ b/tests/test_script_ops.sh
@@ -24,13 +24,17 @@ if [[ ! -d "$LIB_DIR" ]]; then
 fi
 
 # Source required libraries
-# shellcheck source=../lib/utils.sh
+# shellcheck source=lib/utils.sh
+# shellcheck disable=SC1091
 . "$LIB_DIR/utils.sh"
-# shellcheck source=../lib/config.sh
+# shellcheck source=lib/config.sh
+# shellcheck disable=SC1091
 . "$LIB_DIR/config.sh"
-# shellcheck source=../lib/cache.sh
+# shellcheck source=lib/cache.sh
+# shellcheck disable=SC1091
 . "$LIB_DIR/cache.sh"
-# shellcheck source=../lib/script-ops.sh
+# shellcheck source=lib/script-ops.sh
+# shellcheck disable=SC1091
 . "$LIB_DIR/script-ops.sh"
 
 # Test fixtures and setup
@@ -380,5 +384,6 @@ test_rebuild_script_index() {
 }
 
 # Load and run shunit2
-# shellcheck source=../shunit2
+# shellcheck source=shunit2
+# shellcheck disable=SC1091
 . "$PROJECT_ROOT/shunit2"

--- a/tests/test_utils.sh
+++ b/tests/test_utils.sh
@@ -30,7 +30,8 @@ log() {
 
 # Source the library under test
 if [[ -f "$LIB_DIR/utils.sh" ]]; then
-    # shellcheck source=../lib/utils.sh
+    # shellcheck source=lib/utils.sh
+    # shellcheck disable=SC1091
     . "$LIB_DIR/utils.sh"
 else
     echo "ERROR: Cannot find utils.sh at $LIB_DIR/utils.sh" >&2
@@ -267,5 +268,6 @@ test_is_terminal() {
 }
 
 # Load and run shunit2
-# shellcheck source=../shunit2
+# shellcheck source=shunit2
+# shellcheck disable=SC1091
 . "$PROJECT_ROOT/shunit2"


### PR DESCRIPTION
Disable ShellCheck SC1091 warnings in test files to allow dynamic sourcing of libraries and shunit2.

The CI/CD workflow runs ShellCheck on individual test files from the project root. These test files dynamically source common libraries and `shunit2` using variables like `$LIB_DIR` and `$PROJECT_ROOT`. ShellCheck's default behavior cannot resolve these dynamic paths, leading to SC1091 warnings. Since the CI environment cannot be modified to use the `-x` flag or provide additional inputs, disabling this specific warning is the most practical solution for these test scripts.

---
<a href="https://cursor.com/background-agent?bcId=bc-7046e32c-7bf4-4162-9bd4-5f848d66ef06">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7046e32c-7bf4-4162-9bd4-5f848d66ef06">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

